### PR TITLE
Add Multipass contract indexing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,0 @@
-# To create or update a token visit https://envio.dev/app/api-tokens
-ENVIO_API_TOKEN="<YOUR-API-TOKEN>"

--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,6 @@
+# To create or update a token visit https://envio.dev/app/api-tokens
+ENVIO_API_TOKEN="<YOUR-API-TOKEN>"
+export RANKIFY_CONTRACTS_DEPLOYMENTS_PATH="../rankify-contracts/deployments/localhost"
+export MULTIPASS_CONTRACTS_DEPLOYMENTS_PATH="../multipass/deployments/localhost"
+export LOCALHOST_RPC_URL="http://localhost:8545"
+export LOCALHOST_CHAIN_ID=31337

--- a/abi/Multipass.json
+++ b/abi/Multipass.json
@@ -1,0 +1,1462 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "isTest",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidInitialization",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotInitializing",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableInvalidOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableUnauthorizedAccount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ReentrancyGuardReentrantCall",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "domainName",
+        "type": "bytes32"
+      }
+    ],
+    "name": "domainNotActive",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "domainName",
+        "type": "bytes32"
+      }
+    ],
+    "name": "invalidDomain",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "nonce",
+        "type": "uint256"
+      }
+    ],
+    "name": "invalidNonce",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "old",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "newer",
+        "type": "uint256"
+      }
+    ],
+    "name": "invalidNonceIncrement",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "enum IMultipass.InvalidQueryReasons",
+        "name": "reason",
+        "type": "uint8"
+      }
+    ],
+    "name": "invalidQuery",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "registrar",
+        "type": "address"
+      }
+    ],
+    "name": "invalidRegistrar",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "invalidSignature",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "domainName",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "newName",
+        "type": "bytes32"
+      }
+    ],
+    "name": "invalidnameChange",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "name",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bool",
+        "name": "isActive",
+        "type": "bool"
+      }
+    ],
+    "name": "isActive",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "a",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "b",
+        "type": "uint256"
+      }
+    ],
+    "name": "mathOverflow",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "name",
+        "type": "bytes32"
+      }
+    ],
+    "name": "nameExists",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "paymendFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "fee",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "paymentTooLow",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "wallet",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "name",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "id",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint96",
+            "name": "nonce",
+            "type": "uint96"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "domainName",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "validUntil",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct LibMultipass.Record",
+        "name": "newRecord",
+        "type": "tuple"
+      }
+    ],
+    "name": "recordExists",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "referrerReward",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "referralDiscount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "fee",
+        "type": "uint256"
+      }
+    ],
+    "name": "referralRewardsTooHigh",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "referredSelf",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "signatureDeadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "signatureExpired",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "domainName",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "address",
+            "name": "wallet",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "name",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "id",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "targetDomain",
+            "type": "bytes32"
+          }
+        ],
+        "internalType": "struct LibMultipass.NameQuery",
+        "name": "query",
+        "type": "tuple"
+      }
+    ],
+    "name": "userNotFound",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "domainName",
+        "type": "bytes32"
+      }
+    ],
+    "name": "DomainActivated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "domainName",
+        "type": "bytes32"
+      }
+    ],
+    "name": "DomainDeactivated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "domainName",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "newFee",
+        "type": "uint256"
+      }
+    ],
+    "name": "DomainFeeChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "EIP712DomainChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "version",
+        "type": "uint64"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "registrar",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "fee",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "domainName",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "renewalFee",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "referrerReward",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "referralDiscount",
+        "type": "uint256"
+      }
+    ],
+    "name": "InitializedDomain",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "domainName",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "reward",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "discount",
+        "type": "uint256"
+      }
+    ],
+    "name": "ReferralProgramChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "wallet",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "name",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "id",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint96",
+            "name": "nonce",
+            "type": "uint96"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "domainName",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "validUntil",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct LibMultipass.Record",
+        "name": "refferrer",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "wallet",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "name",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "id",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint96",
+            "name": "nonce",
+            "type": "uint96"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "domainName",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "validUntil",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct LibMultipass.Record",
+        "name": "newRecord",
+        "type": "tuple"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "domainName",
+        "type": "bytes32"
+      }
+    ],
+    "name": "Referred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "domainName",
+        "type": "bytes32"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "wallet",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "name",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "id",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint96",
+            "name": "nonce",
+            "type": "uint96"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "domainName",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "validUntil",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct LibMultipass.Record",
+        "name": "NewRecord",
+        "type": "tuple"
+      }
+    ],
+    "name": "Registered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "domainName",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "registrar",
+        "type": "address"
+      }
+    ],
+    "name": "RegistrarChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "domainName",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "newFee",
+        "type": "uint256"
+      }
+    ],
+    "name": "RenewalFeeChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "wallet",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "domainName",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "wallet",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "name",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "id",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint96",
+            "name": "nonce",
+            "type": "uint96"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "domainName",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "validUntil",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct LibMultipass.Record",
+        "name": "newRecord",
+        "type": "tuple"
+      }
+    ],
+    "name": "Renewed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "fundsWithdawn",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "domainName",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "wallet",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "name",
+        "type": "bytes32"
+      }
+    ],
+    "name": "nameDeleted",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "domainName",
+        "type": "bytes32"
+      }
+    ],
+    "name": "activateDomain",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "domainName",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "fee",
+        "type": "uint256"
+      }
+    ],
+    "name": "changeFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "referrerReward",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "referralDiscount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "domainName",
+        "type": "bytes32"
+      }
+    ],
+    "name": "changeReferralProgram",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "domainName",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "newRegistrar",
+        "type": "address"
+      }
+    ],
+    "name": "changeRegistrar",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "fee",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "domainName",
+        "type": "bytes32"
+      }
+    ],
+    "name": "changeRenewalFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "domainName",
+        "type": "bytes32"
+      }
+    ],
+    "name": "deactivateDomain",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "domainName",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "address",
+            "name": "wallet",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "name",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "id",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "targetDomain",
+            "type": "bytes32"
+          }
+        ],
+        "internalType": "struct LibMultipass.NameQuery",
+        "name": "query",
+        "type": "tuple"
+      }
+    ],
+    "name": "deleteName",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "eip712Domain",
+    "outputs": [
+      {
+        "internalType": "bytes1",
+        "name": "fields",
+        "type": "bytes1"
+      },
+      {
+        "internalType": "string",
+        "name": "name",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "version",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "verifyingContract",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "salt",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "extensions",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getContractState",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "domainName",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getDomainState",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "name",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "fee",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "referrerReward",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "referralDiscount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "isActive",
+            "type": "bool"
+          },
+          {
+            "internalType": "address",
+            "name": "registrar",
+            "type": "address"
+          },
+          {
+            "internalType": "uint24",
+            "name": "ttl",
+            "type": "uint24"
+          },
+          {
+            "internalType": "uint256",
+            "name": "registerSize",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "renewalFee",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct LibMultipass.Domain",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "getDomainStateById",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "name",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "fee",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "referrerReward",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "referralDiscount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "isActive",
+            "type": "bool"
+          },
+          {
+            "internalType": "address",
+            "name": "registrar",
+            "type": "address"
+          },
+          {
+            "internalType": "uint24",
+            "name": "ttl",
+            "type": "uint24"
+          },
+          {
+            "internalType": "uint256",
+            "name": "registerSize",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "renewalFee",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct LibMultipass.Domain",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "name",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "version",
+        "type": "string"
+      },
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "registrar",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "fee",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "renewalFee",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "domainName",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "referrerReward",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "referralDiscount",
+        "type": "uint256"
+      }
+    ],
+    "name": "initializeDomain",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "wallet",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "name",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "id",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint96",
+            "name": "nonce",
+            "type": "uint96"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "domainName",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "validUntil",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct LibMultipass.Record",
+        "name": "newRecord",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bytes",
+        "name": "registrarSignature",
+        "type": "bytes"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "domainName",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "address",
+            "name": "wallet",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "name",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "id",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "targetDomain",
+            "type": "bytes32"
+          }
+        ],
+        "internalType": "struct LibMultipass.NameQuery",
+        "name": "referrer",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bytes",
+        "name": "referralCode",
+        "type": "bytes"
+      }
+    ],
+    "name": "register",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "domainName",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "address",
+            "name": "wallet",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "name",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "id",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "targetDomain",
+            "type": "bytes32"
+          }
+        ],
+        "internalType": "struct LibMultipass.NameQuery",
+        "name": "query",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "wallet",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "name",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "id",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint96",
+            "name": "nonce",
+            "type": "uint96"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "domainName",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "validUntil",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct LibMultipass.Record",
+        "name": "record",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bytes",
+        "name": "registrarSignature",
+        "type": "bytes"
+      }
+    ],
+    "name": "renewRecord",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "domainName",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "address",
+            "name": "wallet",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "name",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "id",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "targetDomain",
+            "type": "bytes32"
+          }
+        ],
+        "internalType": "struct LibMultipass.NameQuery",
+        "name": "query",
+        "type": "tuple"
+      }
+    ],
+    "name": "resolveRecord",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "wallet",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "name",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "id",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint96",
+            "name": "nonce",
+            "type": "uint96"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "domainName",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "validUntil",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct LibMultipass.Record",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/config.yaml
+++ b/config.yaml
@@ -83,3 +83,23 @@ networks:
           - event: VotingPeriodSet(uint256 oldVotingPeriod, uint256 newVotingPeriod)
           - event: ProposalThresholdSet(uint256 oldProposalThreshold, uint256 newProposalThreshold)
           - event: QuorumNumeratorUpdated(uint256 oldQuorumNumerator, uint256 newQuorumNumerator)
+      - name: Multipass
+        handler: src/MultipassHandlers.ts
+        address:
+          - 0x3151D65Ad9754eA6A286B7570066FC0d7b9b9856
+        events:
+          - event: DomainActivated(bytes32 indexed domainName)
+          - event: DomainDeactivated(bytes32 indexed domainName)
+          - event: DomainFeeChanged(bytes32 indexed domainName, uint256 indexed newFee)
+          - event: EIP712DomainChanged()
+          - event: Initialized(uint64 version)
+          - event: InitializedDomain(address indexed registrar, uint256 indexed fee, bytes32 indexed domainName, uint256 renewalFee, uint256 referrerReward, uint256 referralDiscount)
+          - event: OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+          - event: ReferralProgramChanged(bytes32 indexed domainName, uint256 reward, uint256 discount)
+          - event: Referred
+          - event: Registered
+          - event: RegistrarChanged(bytes32 indexed domainName, address indexed registrar)
+          - event: RenewalFeeChanged(bytes32 indexed domainName, uint256 indexed newFee)
+          - event: Renewed
+          - event: fundsWithdawn(uint256 indexed amount, address indexed account)
+          - event: nameDeleted(bytes32 indexed domainName, address indexed wallet, bytes32 indexed id, bytes32 name)

--- a/config_local.yaml
+++ b/config_local.yaml
@@ -2,10 +2,11 @@ name: envio-indexer
 field_selection:
   transaction_fields:
     - transactionIndex
+    - hash
 networks:
-  - id: ${CHAIN_ID}
+  - id: ${LOCALHOST_CHAIN_ID}
     rpc_config:
-      url: ${RPC_URL}
+      url: ${LOCALHOST_RPC_URL}
     start_block: 0
     contracts:
       - name: RankifyInstance
@@ -41,7 +42,8 @@ networks:
               proposals)
           - event: >-
               VotingStageResults(uint256 indexed gameId, uint256 indexed roundNumber, address indexed winner, address[]
-              players, uint256[] scores, uint256[][] votesSorted, bool[] isActive, uint256[][] finalizedVotingMatrix, uint256[] permutation)
+              players, uint256[] scores, uint256[][] votesSorted, bool[] isActive, uint256[][] finalizedVotingMatrix,
+              uint256[] permutation)
           - event: StaleGameEnded(uint256 indexed gameId, address indexed winner)
           - event: RequirementsConfigured
       - name: RankifyToken
@@ -106,3 +108,26 @@ networks:
           - event: VotingPeriodSet(uint256 oldVotingPeriod, uint256 newVotingPeriod)
           - event: ProposalThresholdSet(uint256 oldProposalThreshold, uint256 newProposalThreshold)
           - event: QuorumNumeratorUpdated(uint256 oldQuorumNumerator, uint256 newQuorumNumerator)
+      - name: Multipass
+        handler: src/MultipassHandlers.ts
+        abi_file_path: ./abi/Multipass.json
+        address:
+          - ${MULTIPASS_ADDRESS}
+        events:
+          - event: DomainActivated(bytes32 indexed domainName)
+          - event: DomainDeactivated(bytes32 indexed domainName)
+          - event: DomainFeeChanged(bytes32 indexed domainName, uint256 indexed newFee)
+          - event: EIP712DomainChanged()
+          - event: Initialized(uint64 version)
+          - event: >-
+              InitializedDomain(address indexed registrar, uint256 indexed fee, bytes32 indexed domainName, uint256
+              renewalFee, uint256 referrerReward, uint256 referralDiscount)
+          - event: OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+          - event: ReferralProgramChanged(bytes32 indexed domainName, uint256 reward, uint256 discount)
+          - event: Referred
+          - event: Registered
+          - event: RegistrarChanged(bytes32 indexed domainName, address indexed registrar)
+          - event: RenewalFeeChanged(bytes32 indexed domainName, uint256 indexed newFee)
+          - event: Renewed
+          - event: fundsWithdawn(uint256 indexed amount, address indexed account)
+          - event: nameDeleted(bytes32 indexed domainName, address indexed wallet, bytes32 indexed id, bytes32 name)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "mocha": "ts-mocha test/**/*.ts",
     "codegen": "envio codegen",
     "dev": "envio dev",
-    "dev:local": "export RPC_URL=http://localhost:8545 && export CHAIN_ID=31337 && node scripts/start-local.js",
+    "dev:local": ". .env.local && node scripts/start-local.js",
     "dev:clean": "pnpm envio stop && rm -rf generated && rm -rf .envio",
     "test": "pnpm mocha",
     "start": "ts-node generated/src/Index.bs.js"

--- a/schema.graphql
+++ b/schema.graphql
@@ -3,579 +3,713 @@ scalar Bytes
 scalar ID
 
 type DAODistributor_Debug @entity {
-  id: ID!
-  distributorsId: String!
-  args: String!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID!
+    distributorsId: String!
+    args: String!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
 }
 
 type DAODistributor_DefaultAdminDelayChangeCanceled @entity {
-  id: ID!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
 }
 
 type DAODistributor_DefaultAdminDelayChangeScheduled @entity {
-  id: ID!
-  newDelay: BigInt!
-  effectSchedule: BigInt!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID!
+    newDelay: BigInt!
+    effectSchedule: BigInt!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
 }
 
 type DAODistributor_DefaultAdminTransferCanceled @entity {
-  id: ID!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
 }
 
 type DAODistributor_DefaultAdminTransferScheduled @entity {
-  id: ID!
-  newAdmin: String!
-  acceptSchedule: BigInt!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID!
+    newAdmin: String!
+    acceptSchedule: BigInt!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
 }
 
 type DAODistributor_DistributionAdded @entity {
-  id: ID!
-  event_id: String!
-  distribution: String!
-  initializer: String!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID!
+    event_id: String!
+    distribution: String!
+    initializer: String!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
 }
 
 type DAODistributor_DistributionRemoved @entity {
-  id: ID!
-  event_id: String!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID!
+    event_id: String!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
 }
 
 type DAODistributor_Instantiated @entity {
-  id: ID!
-  distributionId: String!
-  newInstanceId: BigInt!
-  version: BigInt!
-  instances: [String!]!
-  args: String!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID!
+    distributionId: String!
+    newInstanceId: BigInt!
+    version: BigInt!
+    instances: [String!]!
+    args: String!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
 }
 
 type DAODistributor_InstantiationCostChanged @entity {
-  id: ID!
-  event_id: String!
-  cost: BigInt!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID!
+    event_id: String!
+    cost: BigInt!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
 }
 
 type DAODistributor_RoleAdminChanged @entity {
-  id: ID!
-  role: String!
-  previousAdminRole: String!
-  newAdminRole: String!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID!
+    role: String!
+    previousAdminRole: String!
+    newAdminRole: String!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
 }
 
 type DAODistributor_RoleGranted @entity {
-  id: ID!
-  role: String!
-  account: String!
-  sender: String!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID!
+    role: String!
+    account: String!
+    sender: String!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
 }
 
 type DAODistributor_RoleRevoked @entity {
-  id: ID!
-  role: String!
-  account: String!
-  sender: String!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID!
+    role: String!
+    account: String!
+    sender: String!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
 }
 
 type DAODistributor_VersionChanged @entity {
-  id: ID!
-  distributionId: String!
-  newRequirement_0_0: BigInt!
-  newRequirement_0_1: BigInt!
-  newRequirement_0_2: BigInt!
-  newRequirement_1: BigInt!
-  newRequirementData_0_0: BigInt!
-  newRequirementData_0_1: BigInt!
-  newRequirementData_0_2: BigInt!
-  newRequirementData_1: BigInt!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID!
+    distributionId: String!
+    newRequirement_0_0: BigInt!
+    newRequirement_0_1: BigInt!
+    newRequirement_0_2: BigInt!
+    newRequirement_1: BigInt!
+    newRequirementData_0_0: BigInt!
+    newRequirementData_0_1: BigInt!
+    newRequirementData_0_2: BigInt!
+    newRequirementData_1: BigInt!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
 }
 
 type IssuanceCurve_Buy @entity {
-  id: ID!
-  buyer: String!
-  amount: BigInt!
-  cost: BigInt!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID!
+    buyer: String!
+    amount: BigInt!
+    cost: BigInt!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
 }
 
 type RankToken_ApprovalForAll @entity {
-  id: ID!
-  account: String!
-  operator: String!
-  approved: Boolean!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID!
+    account: String!
+    operator: String!
+    approved: Boolean!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
 }
 
 type RankToken_Initialized @entity {
-  id: ID!
-  version: BigInt!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID!
+    version: BigInt!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
 }
 
 type RankToken_RankingInstanceUpdated @entity {
-  id: ID!
-  newRankingInstance: String!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID!
+    newRankingInstance: String!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
 }
 
 type RankToken_TokensLocked @entity {
-  id: ID!
-  account: String!
-  event_id: BigInt!
-  value: BigInt!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID!
+    account: String!
+    event_id: BigInt!
+    value: BigInt!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
 }
 
 type RankToken_TokensUnlocked @entity {
-  id: ID!
-  account: String!
-  event_id: BigInt!
-  value: BigInt!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID!
+    account: String!
+    event_id: BigInt!
+    value: BigInt!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
 }
 
 type RankToken_TransferBatch @entity {
-  id: ID!
-  operator: String!
-  from: String!
-  to: String!
-  ids: [BigInt!]!
-  values: [BigInt!]!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID!
+    operator: String!
+    from: String!
+    to: String!
+    ids: [BigInt!]!
+    values: [BigInt!]!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
 }
 
 type RankToken_TransferSingle @entity {
-  id: ID!
-  operator: String!
-  from: String!
-  to: String!
-  event_id: BigInt!
-  value: BigInt!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID!
+    operator: String!
+    from: String!
+    to: String!
+    event_id: BigInt!
+    value: BigInt!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
 }
 
 type RankToken_URI @entity {
-  id: ID!
-  value: String!
-  event_id: BigInt!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID!
+    value: String!
+    event_id: BigInt!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
 }
 
 type RankifyInstance_GameClosed @entity {
-  id: ID!
-  gameId: BigInt!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
-  srcAddress: String!
+    id: ID!
+    gameId: BigInt!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
+    srcAddress: String!
 }
 
 type RankifyInstance_GameOver @entity {
-  id: ID!
-  gameId: BigInt!
-  players: [String!]!
-  scores: [BigInt!]!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
-  srcAddress: String!
+    id: ID!
+    gameId: BigInt!
+    players: [String!]!
+    scores: [BigInt!]!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
+    srcAddress: String!
 }
 
 type RankifyInstance_GameStarted @entity {
-  id: ID!
-  gameId: BigInt!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
-  srcAddress: String!
+    id: ID!
+    gameId: BigInt!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
+    srcAddress: String!
 }
 
 type RankifyInstance_LastTurn @entity {
-  id: ID!
-  gameId: BigInt!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
-  srcAddress: String!
+    id: ID!
+    gameId: BigInt!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
+    srcAddress: String!
 }
 
 type RankifyInstance_OverTime @entity {
-  id: ID!
-  gameId: BigInt!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
-  srcAddress: String!
+    id: ID!
+    gameId: BigInt!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
+    srcAddress: String!
 }
 
 type RankifyInstance_OwnershipTransferred @entity {
-  id: ID!
-  previousOwner: String!
-  newOwner: String!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
-  srcAddress: String!
+    id: ID!
+    previousOwner: String!
+    newOwner: String!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
+    srcAddress: String!
 }
 
 type RankifyInstance_PlayerJoined @entity {
-  id: ID!
-  gameId: BigInt!
-  participant: String!
-  gmCommitment: String!
-  voterPubKey: String!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
-  srcAddress: String!
-  transactionIndex: Int!
-  logIndex: Int!
+    id: ID!
+    gameId: BigInt!
+    participant: String!
+    gmCommitment: String!
+    voterPubKey: String!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
+    srcAddress: String!
+    transactionIndex: Int!
+    logIndex: Int!
 }
 
 type RankifyInstance_PlayerLeft @entity {
-  id: ID!
-  gameId: BigInt!
-  player: String!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
-  srcAddress: String!
+    id: ID!
+    gameId: BigInt!
+    player: String!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
+    srcAddress: String!
 }
 
 type RankifyInstance_ProposalScore @entity {
-  id: ID!
-  gameId: BigInt!
-  roundNumber: BigInt!
-  proposalHash: String!
-  proposal: String!
-  score: BigInt!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
-  srcAddress: String!
+    id: ID!
+    gameId: BigInt!
+    roundNumber: BigInt!
+    proposalHash: String!
+    proposal: String!
+    score: BigInt!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
+    srcAddress: String!
 }
 
 type RankifyInstance_ProposalSubmitted @entity {
-  id: ID!
-  gameId: BigInt!
-  roundNumber: BigInt!
-  proposer: String!
-  commitment: BigInt!
-  encryptedProposal: String!
-  gmSignature: String!
-  proposerSignature: String!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
-  srcAddress: String!
+    id: ID!
+    gameId: BigInt!
+    roundNumber: BigInt!
+    proposer: String!
+    commitment: BigInt!
+    encryptedProposal: String!
+    gmSignature: String!
+    proposerSignature: String!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
+    srcAddress: String!
 }
 
 type RankifyInstance_RankTokenExited @entity {
-  id: ID!
-  player: String!
-  rankId: BigInt!
-  amount: BigInt!
-  _toMint: BigInt!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
-  srcAddress: String!
+    id: ID!
+    player: String!
+    rankId: BigInt!
+    amount: BigInt!
+    _toMint: BigInt!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
+    srcAddress: String!
 }
 
 type RankifyInstance_RegistrationOpen @entity {
-  id: ID!
-  gameId: BigInt!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
-  srcAddress: String!
+    id: ID!
+    gameId: BigInt!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
+    srcAddress: String!
 }
 
 type RequirementsConfigured_Contract {
-  id: ID!
-  requirementsConfiguredEvent: RankifyInstance_RequirementsConfigured!
-  contractAddress: String!
-  contractId: BigInt!
-  contractType: BigInt!
-  have_data: String!
-  have_amount: BigInt!
-  lock_data: String!
-  lock_amount: BigInt!
-  burn_data: String!
-  burn_amount: BigInt!
-  pay_data: String!
-  pay_amount: BigInt!
-  bet_data: String!
-  bet_amount: BigInt!
+    id: ID!
+    requirementsConfiguredEvent: RankifyInstance_RequirementsConfigured!
+    contractAddress: String!
+    contractId: BigInt!
+    contractType: BigInt!
+    have_data: String!
+    have_amount: BigInt!
+    lock_data: String!
+    lock_amount: BigInt!
+    burn_data: String!
+    burn_amount: BigInt!
+    pay_data: String!
+    pay_amount: BigInt!
+    bet_data: String!
+    bet_amount: BigInt!
 }
 
 type RankifyInstance_RequirementsConfigured {
-  id: ID!
-  gameId: BigInt!
-  ethValues_have: BigInt!
-  ethValues_lock: BigInt!
-  ethValues_burn: BigInt!
-  ethValues_pay: BigInt!
-  ethValues_bet: BigInt!
-  contracts: [RequirementsConfigured_Contract!]! @derivedFrom(field: "requirementsConfiguredEvent")
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  srcAddress: String!
+    id: ID!
+    gameId: BigInt!
+    ethValues_have: BigInt!
+    ethValues_lock: BigInt!
+    ethValues_burn: BigInt!
+    ethValues_pay: BigInt!
+    ethValues_bet: BigInt!
+    contracts: [RequirementsConfigured_Contract!]!
+        @derivedFrom(field: "requirementsConfiguredEvent")
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    srcAddress: String!
 }
 
 type RankifyInstance_VoteSubmitted @entity {
-  id: ID!
-  gameId: BigInt!
-  roundNumber: BigInt!
-  player: String!
-  sealedBallotId: String!
-  gmSignature: String!
-  voterSignature: String!
-  ballotHash: String!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
-  srcAddress: String!
+    id: ID!
+    gameId: BigInt!
+    roundNumber: BigInt!
+    player: String!
+    sealedBallotId: String!
+    gmSignature: String!
+    voterSignature: String!
+    ballotHash: String!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
+    srcAddress: String!
 }
 
 type RankifyInstance_gameCreated @entity {
-  id: ID!
-  gameId: BigInt!
-  gm: String!
-  creator: String!
-  rank: BigInt!
-  proposingPhaseDuration: BigInt!
-  votePhaseDuration: BigInt!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
-  srcAddress: String!
+    id: ID!
+    gameId: BigInt!
+    gm: String!
+    creator: String!
+    rank: BigInt!
+    proposingPhaseDuration: BigInt!
+    votePhaseDuration: BigInt!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
+    srcAddress: String!
 }
 
 type RankifyInstance_ProposingStageEnded @entity {
-  id: ID!
-  gameId: BigInt!
-  roundNumber: BigInt!
-  numProposals: BigInt!
-  proposals: [String!]!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
-  srcAddress: String!
+    id: ID!
+    gameId: BigInt!
+    roundNumber: BigInt!
+    numProposals: BigInt!
+    proposals: [String!]!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
+    srcAddress: String!
 }
 
 type RankifyInstance_VotingStageResults @entity {
-  id: ID!
-  gameId: BigInt!
-  roundNumber: BigInt!
-  winner: String!
-  players: [String!]!
-  scores: [BigInt!]!
-  votesSorted: [[BigInt!]!]!
-  isActive: [Int!]!
-  finalizedVotingMatrix: [[BigInt!]!]!
-  permutation: [BigInt!]!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
-  srcAddress: String!
+    id: ID!
+    gameId: BigInt!
+    roundNumber: BigInt!
+    winner: String!
+    players: [String!]!
+    scores: [BigInt!]!
+    votesSorted: [[BigInt!]!]!
+    isActive: [Int!]!
+    finalizedVotingMatrix: [[BigInt!]!]!
+    permutation: [BigInt!]!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
+    srcAddress: String!
 }
 
 type RankifyInstance_StaleGameEnded @entity {
-  id: ID!
-  gameId: BigInt!
-  winner: String!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
-  srcAddress: String!
+    id: ID!
+    gameId: BigInt!
+    winner: String!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
+    srcAddress: String!
 }
 
 type GovernorProposal @entity {
-  id: ID! # proposalId
-  governorAddress: String! # MODIFIED: Address of the Governor contract, from event.srcAddress
-  proposer: String! # Address of the proposer
-  targets: [String!]!
-  values: [BigInt!]!
-  signatures: [String!]! # Function signatures
-  calldatas: [Bytes!]!
-  voteStart: BigInt! # Block number
-  voteEnd: BigInt! # Block number
-  description: String!
-  state: String! # e.g., Pending, Active, Canceled, Defeated, Succeeded, Queued, Expired, Executed
-  eta: BigInt # Execution timestamp, if queued
-  forVotes: BigInt!
-  againstVotes: BigInt!
-  abstainVotes: BigInt!
-  canceled: Boolean!
-  executed: Boolean!
-  queued: Boolean!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID! # proposalId
+    governorAddress: String! # MODIFIED: Address of the Governor contract, from event.srcAddress
+    proposer: String! # Address of the proposer
+    targets: [String!]!
+    values: [BigInt!]!
+    signatures: [String!]! # Function signatures
+    calldatas: [Bytes!]!
+    voteStart: BigInt! # Block number
+    voteEnd: BigInt! # Block number
+    description: String!
+    state: String! # e.g., Pending, Active, Canceled, Defeated, Succeeded, Queued, Expired, Executed
+    eta: BigInt # Execution timestamp, if queued
+    forVotes: BigInt!
+    againstVotes: BigInt!
+    abstainVotes: BigInt!
+    canceled: Boolean!
+    executed: Boolean!
+    queued: Boolean!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
 }
 
 type GovernorVote @entity {
-  id: ID! # Combination of voter address and proposalId
-  governorAddress: String! # MODIFIED: Address of the Governor contract, from event.srcAddress
-  voter: String! # Address of the voter
-  proposal: GovernorProposal! # Link to the proposal entity by its ID (proposalId)
-  support: Int! # 0: Against, 1: For, 2: Abstain
-  weight: BigInt!
-  reason: String
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID! # Combination of voter address and proposalId
+    governorAddress: String! # MODIFIED: Address of the Governor contract, from event.srcAddress
+    voter: String! # Address of the voter
+    proposal: GovernorProposal! # Link to the proposal entity by its ID (proposalId)
+    support: Int! # 0: Against, 1: For, 2: Abstain
+    weight: BigInt!
+    reason: String
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
 }
 
 type GovernorVotingDelaySet @entity {
-  id: ID! # transaction hash + log index
-  governorAddress: String! # MODIFIED: Address of the Governor contract, from event.srcAddress
-  oldVotingDelay: BigInt!
-  newVotingDelay: BigInt!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID! # transaction hash + log index
+    governorAddress: String! # MODIFIED: Address of the Governor contract, from event.srcAddress
+    oldVotingDelay: BigInt!
+    newVotingDelay: BigInt!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
 }
 
 type GovernorVotingPeriodSet @entity {
-  id: ID!
-  governorAddress: String! # MODIFIED: Address of the Governor contract, from event.srcAddress
-  oldVotingPeriod: BigInt!
-  newVotingPeriod: BigInt!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID!
+    governorAddress: String! # MODIFIED: Address of the Governor contract, from event.srcAddress
+    oldVotingPeriod: BigInt!
+    newVotingPeriod: BigInt!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
 }
 
 type GovernorProposalThresholdSet @entity {
-  id: ID!
-  governorAddress: String! # MODIFIED: Address of the Governor contract, from event.srcAddress
-  oldProposalThreshold: BigInt!
-  newProposalThreshold: BigInt!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID!
+    governorAddress: String! # MODIFIED: Address of the Governor contract, from event.srcAddress
+    oldProposalThreshold: BigInt!
+    newProposalThreshold: BigInt!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
 }
 
 type GovernorQuorumNumeratorUpdated @entity {
-  id: ID!
-  governorAddress: String! # MODIFIED: Address of the Governor contract, from event.srcAddress
-  oldQuorumNumerator: BigInt!
-  newQuorumNumerator: BigInt!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID!
+    governorAddress: String! # MODIFIED: Address of the Governor contract, from event.srcAddress
+    oldQuorumNumerator: BigInt!
+    newQuorumNumerator: BigInt!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
 }
 
 type RankifyToken_Approval @entity {
-  id: ID!
-  owner: String!
-  spender: String!
-  value: BigInt!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID!
+    owner: String!
+    spender: String!
+    value: BigInt!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
 }
 
 type RankifyToken_DelegateChanged @entity {
-  id: ID!
-  delegator: String!
-  fromDelegate: String!
-  toDelegate: String!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID!
+    delegator: String!
+    fromDelegate: String!
+    toDelegate: String!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
 }
 
 type RankifyToken_DelegateVotesChanged @entity {
-  id: ID!
-  delegate: String!
-  previousVotes: BigInt!
-  newVotes: BigInt!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID!
+    delegate: String!
+    previousVotes: BigInt!
+    newVotes: BigInt!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
 }
 
 type RankifyToken_EIP712DomainChanged @entity {
-  id: ID!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
 }
 
 type RankifyToken_OwnershipTransferred @entity {
-  id: ID!
-  previousOwner: String!
-  newOwner: String!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID!
+    previousOwner: String!
+    newOwner: String!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
 }
 
 type RankifyToken_Transfer @entity {
-  id: ID!
-  from: String!
-  to: String!
-  value: BigInt!
-  blockNumber: BigInt!
-  blockTimestamp: String!
-  chainId: Int!
+    id: ID!
+    from: String!
+    to: String!
+    value: BigInt!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
+}
+
+type MultipassDomainActivated @entity {
+    id: ID!
+    domainName: String!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
+    hash: String!
+}
+
+type MultipassDomainDeactivated @entity {
+    id: ID!
+    domainName: String!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
+    hash: String!
+}
+
+type MultipassDomainFeeChanged @entity {
+    id: ID!
+    domainName: String!
+    newFee: BigInt!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
+    hash: String!
+}
+
+type MultipassInitializedDomain @entity {
+    id: ID!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
+    hash: String!
+    registrar: String!
+    fee: BigInt!
+    domainName: String!
+    renewalFee: BigInt!
+    referrerReward: BigInt!
+    referralDiscount: BigInt!
+}
+
+type MultipassOwnershipTransferred @entity {
+    id: ID!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
+    hash: String!
+    previousOwner: String!
+    newOwner: String!
+}
+
+type MultipassReferralProgramChanged @entity {
+    id: ID!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
+    hash: String!
+    domainName: String!
+    reward: BigInt!
+    discount: BigInt!
+}
+
+type MultipassRegistered @entity {
+    id: ID!
+    domainName: String!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
+    hash: String!
+    wallet: String!
+    userId: String!
+    nonce: BigInt!
+    validUntil: BigInt!
+    name: String!
+}
+
+type MultipassRegistrarChanged @entity {
+    id: ID!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
+    hash: String!
+    domainName: String!
+    registrar: String!
+}
+
+type MultipassRenewalFeeChanged @entity {
+    id: ID!
+    domainName: String!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
+    hash: String!
+    newFee: BigInt!
+}
+
+type MultipassRenewed @entity {
+    id: ID!
+    domainName: String!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
+    hash: String!
+    wallet: String!
+    userId: String!
+    nonce: BigInt!
+    validUntil: BigInt!
+    name: String!
+}
+
+type MultipassfundsWithdawn @entity {
+    id: ID!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
+    hash: String!
+    account: String!
+    amount: BigInt!
+}
+
+type MultipassNameDeleted @entity {
+    id: ID!
+    domainName: String!
+    blockNumber: BigInt!
+    blockTimestamp: String!
+    chainId: Int!
+    hash: String!
+    wallet: String!
+    userId: String!
+    name: String!
 }

--- a/scripts/start-local.js
+++ b/scripts/start-local.js
@@ -5,12 +5,8 @@ const path = require("path");
 const { execSync } = require("child_process");
 const yaml = require("js-yaml");
 
-
-// Path to the deployment artifacts
-const deploymentsPath = path.resolve(__dirname, "../../contracts/deployments/localhost");
-
 // Function to read contract address from deployment JSON file
-function getContractAddress(contractName) {
+function getContractAddress(contractName, deploymentsPath) {
   try {
     const artifactPath = path.join(deploymentsPath, `${contractName}.json`);
     const artifactContent = fs.readFileSync(artifactPath, "utf8");
@@ -22,12 +18,37 @@ function getContractAddress(contractName) {
   }
 }
 
+if (!process.env.RANKIFY_CONTRACTS_DEPLOYMENTS_PATH) {
+  console.error(
+    "RANKIFY_CONTRACTS_DEPLOYMENTS_PATH environment variable is not set.",
+  );
+  process.exit(1);
+}
+if (!process.env.MULTIPASS_CONTRACTS_DEPLOYMENTS_PATH) {
+  console.error(
+    "MULTIPASS_CONTRACTS_DEPLOYMENTS_PATH environment variable is not set.",
+  );
+  process.exit(1);
+}
+
 // Get contract addresses
-const rankifyTokenAddress = getContractAddress("Rankify");
-const daoDistributorAddress = getContractAddress("DAODistributor");
+const rankifyTokenAddress = getContractAddress(
+  "Rankify",
+  process.env.RANKIFY_CONTRACTS_DEPLOYMENTS_PATH,
+);
+const daoDistributorAddress = getContractAddress(
+  "DAODistributor",
+  process.env.RANKIFY_CONTRACTS_DEPLOYMENTS_PATH,
+);
+
+const multipassAddress = getContractAddress(
+  "Multipass",
+  process.env.MULTIPASS_CONTRACTS_DEPLOYMENTS_PATH,
+);
 
 console.log(`Found Rankify at: ${rankifyTokenAddress}`);
 console.log(`Found DAODistributor at: ${daoDistributorAddress}`);
+console.log(`Found Multipass at: ${multipassAddress}`);
 
 // Path to the config file
 const configPath = path.resolve(__dirname, "../config_local.yaml");
@@ -43,19 +64,33 @@ try {
 
   // Create or update .env file with the addresses
   const envPath = path.resolve(__dirname, "../.env");
-  let envContent = fs.existsSync(envPath) ? fs.readFileSync(envPath, "utf8") : "";
+  let envContent = fs.existsSync(envPath)
+    ? fs.readFileSync(envPath, "utf8")
+    : "";
 
   fs.writeFileSync(envPath, envContent.trim() + "\n");
-  console.log("Environment file updated with contract addresses and port configuration");
+  console.log(
+    "Environment file updated with contract addresses and port configuration",
+  );
 
   process.chdir(path.resolve(__dirname, ".."));
 
-
-  execSync("pnpm envio codegen --config config_local.yaml && pnpm dev --config config_local.yaml", {
-    stdio: "inherit",
-    env: { ...process.env, RANKIFY_TOKEN_ADDRESS:rankifyTokenAddress, DAO_DISTRIBUTOR_ADDRESS:  daoDistributorAddress },
-  });
+  execSync(
+    "pnpm envio codegen --config config_local.yaml && pnpm dev --config config_local.yaml",
+    {
+      stdio: "inherit",
+      env: {
+        ...process.env,
+        RANKIFY_TOKEN_ADDRESS: rankifyTokenAddress,
+        DAO_DISTRIBUTOR_ADDRESS: daoDistributorAddress,
+        MULTIPASS_ADDRESS: multipassAddress,
+      },
+    },
+  );
 } catch (error) {
-  console.error("Error updating config or starting development server:", error.message);
+  console.error(
+    "Error updating config or starting development server:",
+    error.message,
+  );
   process.exit(1);
 }

--- a/src/MultipassHandlers.ts
+++ b/src/MultipassHandlers.ts
@@ -1,0 +1,200 @@
+/*
+ * Please refer to https://docs.envio.dev for a thorough guide on all Envio indexer features
+ */
+import {
+  Multipass,
+  MultipassDomainActivated,
+  MultipassDomainDeactivated,
+  MultipassDomainFeeChanged,
+  MultipassfundsWithdawn,
+  MultipassInitializedDomain,
+  MultipassNameDeleted,
+  MultipassOwnershipTransferred,
+  MultipassReferralProgramChanged,
+  MultipassRegistered,
+  MultipassRegistrarChanged,
+  MultipassRenewalFeeChanged,
+  MultipassRenewed,
+} from "generated";
+import { randomUUID } from "crypto";
+
+Multipass.DomainActivated.handler(async ({ event, context }) => {
+  const entity: MultipassDomainActivated = {
+    id: `${event.chainId}_${event.block.number}_${event.logIndex}`,
+    ...event.params,
+    blockNumber: BigInt(event.block.number),
+    blockTimestamp: new Date(
+      Number(event.block.timestamp) * 1000,
+    ).toISOString(),
+    chainId: event.chainId,
+    hash: event.transaction.hash,
+  };
+  context.MultipassDomainActivated.set(entity);
+});
+
+Multipass.DomainDeactivated.handler(async ({ event, context }) => {
+  const entity: MultipassDomainDeactivated = {
+    id: `${event.chainId}_${event.block.number}_${event.logIndex}`,
+    ...event.params,
+    blockNumber: BigInt(event.block.number),
+    blockTimestamp: new Date(
+      Number(event.block.timestamp) * 1000,
+    ).toISOString(),
+    chainId: event.chainId,
+    hash: event.transaction.hash,
+  };
+  context.MultipassDomainDeactivated.set(entity);
+});
+
+Multipass.DomainFeeChanged.handler(async ({ event, context }) => {
+  const entity: MultipassDomainFeeChanged = {
+    id: `${event.chainId}_${event.block.number}_${event.logIndex}`,
+    ...event.params,
+    blockNumber: BigInt(event.block.number),
+    blockTimestamp: new Date(
+      Number(event.block.timestamp) * 1000,
+    ).toISOString(),
+    chainId: event.chainId,
+    hash: event.transaction.hash,
+  };
+  context.MultipassDomainFeeChanged.set(entity);
+});
+
+Multipass.InitializedDomain.handler(async ({ event, context }) => {
+  const entity: MultipassInitializedDomain = {
+    id: `${event.chainId}_${event.block.number}_${event.logIndex}`,
+    ...event.params,
+    blockNumber: BigInt(event.block.number),
+    blockTimestamp: new Date(
+      Number(event.block.timestamp) * 1000,
+    ).toISOString(),
+    chainId: event.chainId,
+    hash: event.transaction.hash,
+  };
+  context.MultipassInitializedDomain.set(entity);
+});
+
+Multipass.OwnershipTransferred.handler(async ({ event, context }) => {
+  const entity: MultipassOwnershipTransferred = {
+    id: `${event.chainId}_${event.block.number}_${event.logIndex}`,
+    ...event.params,
+    blockNumber: BigInt(event.block.number),
+    blockTimestamp: new Date(
+      Number(event.block.timestamp) * 1000,
+    ).toISOString(),
+    chainId: event.chainId,
+    hash: event.transaction.hash,
+  };
+  context.MultipassOwnershipTransferred.set(entity);
+});
+
+Multipass.ReferralProgramChanged.handler(async ({ event, context }) => {
+  const entity: MultipassReferralProgramChanged = {
+    id: `${event.chainId}_${event.block.number}_${event.logIndex}`,
+    ...event.params,
+    blockNumber: BigInt(event.block.number),
+    blockTimestamp: new Date(
+      Number(event.block.timestamp) * 1000,
+    ).toISOString(),
+    chainId: event.chainId,
+    hash: event.transaction.hash,
+  };
+  context.MultipassReferralProgramChanged.set(entity);
+});
+
+Multipass.Registered.handler(async ({ event, context }) => {
+  const entity: MultipassRegistered = {
+    id: `${event.chainId}_${event.block.number}_${event.logIndex}`,
+    wallet: event.params.NewRecord[0],
+    name: event.params.NewRecord[1],
+    userId: event.params.NewRecord[2],
+    nonce: event.params.NewRecord[3],
+    domainName: event.params.NewRecord[4],
+    validUntil: event.params.NewRecord[5],
+    blockNumber: BigInt(event.block.number),
+    blockTimestamp: new Date(
+      Number(event.block.timestamp) * 1000,
+    ).toISOString(),
+    chainId: event.chainId,
+    hash: event.transaction.hash,
+  };
+  context.MultipassRegistered.set(entity);
+});
+
+Multipass.RegistrarChanged.handler(async ({ event, context }) => {
+  const entity: MultipassRegistrarChanged = {
+    id: `${event.chainId}_${event.block.number}_${event.logIndex}`,
+    ...event.params,
+    blockNumber: BigInt(event.block.number),
+    blockTimestamp: new Date(
+      Number(event.block.timestamp) * 1000,
+    ).toISOString(),
+    chainId: event.chainId,
+    hash: event.transaction.hash,
+  };
+  context.MultipassRegistrarChanged.set(entity);
+});
+
+Multipass.RenewalFeeChanged.handler(async ({ event, context }) => {
+  const entity: MultipassRenewalFeeChanged = {
+    id: `${event.chainId}_${event.block.number}_${event.logIndex}`,
+    ...event.params,
+    blockNumber: BigInt(event.block.number),
+    blockTimestamp: new Date(
+      Number(event.block.timestamp) * 1000,
+    ).toISOString(),
+    chainId: event.chainId,
+    hash: event.transaction.hash,
+  };
+  context.MultipassRenewalFeeChanged.set(entity);
+});
+
+Multipass.Renewed.handler(async ({ event, context }) => {
+  const entity: MultipassRenewed = {
+    id: `${event.chainId}_${event.block.number}_${event.logIndex}`,
+    wallet: event.params.newRecord[0],
+    name: event.params.newRecord[1],
+    userId: event.params.newRecord[2],
+    nonce: event.params.newRecord[3],
+    domainName: event.params.newRecord[4],
+    validUntil: event.params.newRecord[5],
+    blockNumber: BigInt(event.block.number),
+    blockTimestamp: new Date(
+      Number(event.block.timestamp) * 1000,
+    ).toISOString(),
+    chainId: event.chainId,
+    hash: event.transaction.hash,
+  };
+  context.MultipassRenewalFeeChanged.set(entity);
+});
+
+Multipass.FundsWithdawn.handler(async ({ event, context }) => {
+  const entity: MultipassfundsWithdawn = {
+    id: `${event.chainId}_${event.block.number}_${event.logIndex}`,
+    ...event.params,
+    blockNumber: BigInt(event.block.number),
+    blockTimestamp: new Date(
+      Number(event.block.timestamp) * 1000,
+    ).toISOString(),
+    chainId: event.chainId,
+    hash: event.transaction.hash,
+  };
+  context.MultipassfundsWithdawn.set(entity);
+});
+
+Multipass.NameDeleted.handler(async ({ event, context }) => {
+  const entity: MultipassNameDeleted = {
+    id: `${event.chainId}_${event.block.number}_${event.logIndex}`,
+    wallet: event.params.wallet,
+    name: event.params.name,
+    userId: event.params.id,
+    domainName: event.params.domainName,
+    blockNumber: BigInt(event.block.number),
+    blockTimestamp: new Date(
+      Number(event.block.timestamp) * 1000,
+    ).toISOString(),
+    chainId: event.chainId,
+    hash: event.transaction.hash,
+  };
+  context.MultipassNameDeleted.set(entity);
+});


### PR DESCRIPTION
Integrate Multipass contract ABI and define new GraphQL entities for its events. Set up event handlers for all Multipass events. Refactor local development setup to use `.env.local` for dynamic contract addresses and network configuration, and remove the redundant `.env.example` file.